### PR TITLE
Development - 2.0.0rc4

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ StaticTimer.time_it("2**64", runs=5, iterations_per_run=10000)
  * Multiple runs can be measured then averaged together to get a more accurate result
  * Any needed `globals` or `locals` can be specified by passing `globals=` and `locals=`
 
- `time_it` can be used to re-write the decorator above example like so:
- ```python
- StaticTimer.time_it(factorial, lambda: randint(3, 40), call_callable_args=True, average_runs=False, runs=5, log_arguments=True)
- ```
+`time_it` can be used to re-write the decorator above example like so:
+```python
+StaticTimer.time_it(factorial, lambda: randint(3, 40), call_callable_args=True, average_runs=False, runs=5, log_arguments=True)
+```
 
 ### Assume
 ```python
@@ -208,7 +208,7 @@ def binary_search(sorted_array, element):
     return None  # couldn't find it
 
 binary_search(lambda: [i for i in range(randint(0, 10000))], lambda: randint(0, 10000))
-timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude_args={1}, transformers={0: len}), key=0,
+timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude={1}, transformers={0: len}), key=0,
            transformer=len, time_unit=timer.US, x_label="List Length", equation_rounding=4,
            title="Binary Search - Random Size, Random Element")
 ```
@@ -224,7 +224,7 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude_args={1}, transfo
 ## TODO
  - [ ] Add `.predict(params, arguments)` to `Timer`. Should basically be a
  pass-through call to `.calculate_point()` on the correct best-fit-curve
- - [ ] Collapse `exclude_args` and `exclude_kwargs` down into just `exclude`.
+ - [x] Collapse `exclude_args` and `exclude_kwargs` down into just `exclude`.
  The difference between positional and keyword arguments can be determined as
  int vs. str.
  - [x] Change how coefficients are returned for `BestFitLinear`, maybe use

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude_args={1}, transfo
  - [ ] Collapse `exclude_args` and `exclude_kwargs` down into just `exclude`.
  The difference between positional and keyword arguments can be determined as
  int vs. str.
- - [ ] Change how coefficients are returned for `BestFitLinear`, maybe use
+ - [x] Change how coefficients are returned for `BestFitLinear`, maybe use
  **x<sub>index/key</sub>**
  - [x] Add context manager
  - [x] Make scipy, numpy, and scikit-learn optional, just prohibit `best_fit_curve` if they aren't there

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ pip install exectiming
 ```
 For full functionality:
 
- * `scipy`
- * `scikit-learn`
- * `numpy`
- * `matplotlib`
+ * `scipy` - for best-fit-curve
+ * `scikit-learn` - for best-fit-curve
+ * `numpy` - for best-fit-curve
+ * `matplotlib` - for plotting
 
 However, basic functionality will still exist even if those dependencies aren't found
 
@@ -63,7 +63,6 @@ def factorial(n):
         return n * factorial.__wrapped__(n-1)
 
 factorial(lambda: randint(3, 40))
-
 #    0.01663 ms - factorial(33) ... [runs=  1, iterations=  1] | Run 1
 #    0.00544 ms - factorial(19) ... [runs=  1, iterations=  1] | Run 2
 #    0.00736 ms - factorial(28) ... [runs=  1, iterations=  1] | Run 3
@@ -193,8 +192,6 @@ timer.plot(transformer=len, plot_curve=True, curve=curve, x_label="List Length")
 ```python
 @timer.decorate(runs=100, iterations_per_run=5, log_arguments=True, call_callable_args=True)
 def binary_search(sorted_array, element):
-    # print(len(sorted_array))
-
     lower, upper = 0, len(sorted_array)
     middle = upper // 2
 
@@ -225,6 +222,14 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude_args={1}, transfo
  * Additionally, the title and x-axis labels are specified and rounding set lower
 
 ## TODO
+ - [ ] Add `.predict(params, arguments)` to `Timer`. Should basically be a
+ pass-through call to `.calculate_point()` on the correct best-fit-curve
+ - [ ] Collapse `exclude_args` and `exclude_kwargs` down into just `exclude`.
+ The difference between positional and keyword arguments can be determined as
+ int vs. str.
+ - [ ] Change how coefficients are returned for `BestFitLinear`, maybe use
+ **x<sub>index/key</sub>**
+ - [x] Add context manager
  - [x] Make scipy, numpy, and scikit-learn optional, just prohibit `best_fit_curve` if they aren't there
  - [x] Add graphing feature with matplotlib, Linear will only be graphed if there is a single argument
  - [x] Add the ability to sort runs so they are display in some sort of order. Maybe allow sorting

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude={1}, transformers
  * Additionally, the title and x-axis labels are specified and rounding set lower
 
 ## TODO
+ - [x] Change `.output()` to not require `split_index` if `transformers={0:len}`. 
+ Allow `transformers` to be just a function, if there is only one argument, or a map 
+ or a map of a map.
  - [x] Change `.sort_runs()` to reflect that values don't have to be integers, 
  they just have to be comparable. If they aren't, then a transformer is needed. 
  This change is mainly cosmetic. (BJ - nothing actually needed changed)

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude={1}, transformers
  * Additionally, the title and x-axis labels are specified and rounding set lower
 
 ## TODO
+ - [x] Change `.sort_runs()` to reflect that values don't have to be integers, 
+ they just have to be comparable. If they aren't, then a transformer is needed. 
+ This change is mainly cosmetic. (BJ - nothing actually needed changed)
  - [x] Add `.predict(params, arguments)` to `Timer`. Should basically be a
  pass-through call to `.calculate_point()` on the correct best-fit-curve
  - [x] Collapse `exclude_args` and `exclude_kwargs` down into just `exclude`.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude={1}, transformers
  * Additionally, the title and x-axis labels are specified and rounding set lower
 
 ## TODO
- - [ ] Add `.predict(params, arguments)` to `Timer`. Should basically be a
+ - [x] Add `.predict(params, arguments)` to `Timer`. Should basically be a
  pass-through call to `.calculate_point()` on the correct best-fit-curve
  - [x] Collapse `exclude_args` and `exclude_kwargs` down into just `exclude`.
  The difference between positional and keyword arguments can be determined as

--- a/exectiming/best_fit_curves.py
+++ b/exectiming/best_fit_curves.py
@@ -27,11 +27,10 @@ try:
     from scipy.optimize import curve_fit
     import numpy as np
 
+    np.seterr(divide="ignore")
     MISSING_CURVE_FITTING = False
 except ImportError:
     MISSING_CURVE_FITTING = True
-
-np.seterr(divide="ignore")
 
 
 class BestFitBase:
@@ -117,7 +116,7 @@ class BestFitExponential(BestFitBase):
         flattened_args, matching_points = BestFitBase._flatten_args_separate_points(points)
         # set default params low as measured times can be very short
         values = curve_fit(lambda x, a, b: a + b*np.exp(x), [val[0] for val in flattened_args],
-                           matching_points, p0=(0.000001, 0.000001))
+                           matching_points, p0=(0.0000001, 0.0000001))
 
         return {"a": values[0][0], "b": values[0][1]}
 
@@ -128,7 +127,7 @@ class BestFitExponential(BestFitBase):
 
     @staticmethod
     def equation(parameters, rounding=8):
-        return "y = {} + {}*e^x".format(round(parameters["a"], rounding), round(parameters["b"], rounding))
+        return "y = {} + {}e^x".format(round(parameters["a"], rounding), round(parameters["b"], rounding))
 
     @staticmethod
     def poll(points):

--- a/exectiming/best_fit_curves.py
+++ b/exectiming/best_fit_curves.py
@@ -88,7 +88,7 @@ class BestFitBase:
     @staticmethod
     def poll(points: List[Tuple[Dict[Union[str, int], int], float]]) -> bool:
         """
-        Determine if this best fit method will work with the given data
+        Return True if this best-fit-curve type can operate on these data points. Otherwise, return False
         """
         return not MISSING_CURVE_FITTING
 
@@ -138,8 +138,8 @@ class BestFitExponential(BestFitBase):
 class BestFitLinear(BestFitBase):
     """
     Uses sklearn.linear_model.LinearRegression to determine coefficients for each of the independent variables and
-    the y-intercept. Generate parameters are the y-intercept, `b`, and coefficients where the key is the index of the
-    argument or its key depending on whether it is a positional or keyword argument, respectively.
+    the y-intercept. Generate parameters are the y-intercept, `b`, and coefficients where the key is
+    `x_index/key`. The index or key is the index of a positional argument or the name of a keyword argument.
     """
     @staticmethod
     def calculate_curve(points):
@@ -150,8 +150,8 @@ class BestFitLinear(BestFitBase):
 
         params = {"b": model.intercept_}
         i = 0
-        for key in range(len(points[0][0])):
-            params[key] = model.coef_[i]
+        for key in points[0][0]:  # for all the keys, assuming stable iteration
+            params["x_{}".format(key)] = model.coef_[i]
             i += 1
 
         return params
@@ -161,7 +161,7 @@ class BestFitLinear(BestFitBase):
         value = parameters["b"]
 
         for key in arguments:
-            value += arguments[key] * parameters[key]
+            value += arguments[key] * parameters["x_{}".format(key)]
 
         return value
 
@@ -169,7 +169,7 @@ class BestFitLinear(BestFitBase):
     def equation(parameters, rounding=8):
         return "y = {} + {}".format(
             round(parameters["b"], rounding),
-            " + ".join("{}x_{}".format(round(value, rounding), key) for key, value in parameters.items() if key != "b")
+            " + ".join("{}{}".format(round(value, rounding), key) for key, value in parameters.items() if key != "b")
         )
 
 

--- a/exectiming/best_fit_curves.py
+++ b/exectiming/best_fit_curves.py
@@ -168,7 +168,7 @@ class BestFitLinear(BestFitBase):
     @staticmethod
     def equation(parameters, rounding=8):
         return "y = {} + {}".format(
-            parameters["b"],
+            round(parameters["b"], rounding),
             " + ".join("{}x_{}".format(round(value, rounding), key) for key, value in parameters.items() if key != "b")
         )
 

--- a/exectiming/data_structures.py
+++ b/exectiming/data_structures.py
@@ -90,7 +90,7 @@ class Split:
             best: Tuple[float, str, dict] = None  # tuple of distance, name, and parameters
             for bfc_name, bfc in self.best_fit_curves.items():
                 if not bfc.poll(points):
-                    return
+                    continue
 
                 params = bfc.calculate_curve(points)
 

--- a/exectiming/data_structures.py
+++ b/exectiming/data_structures.py
@@ -52,7 +52,7 @@ class Split:
         else:
             return 0
 
-    def determine_best_fit(self, curve_type: str=any, exclude_args: Set[int]=(), exclude_kwargs: set=(),
+    def determine_best_fit(self, curve_type: str=any, exclude: Set[Union[str, int]]=(),
                            transformers: Dict[Union[int, str], callable]=()) -> Union[None, Tuple[str, dict]]:
         """
         Determine the best fit curve for the runs contained in this split.
@@ -77,12 +77,9 @@ class Split:
                     if key in transformers:
                         new_kwargs[key] = transformers[key](new_kwargs[key])
 
-            # EXCLUDE ARGUMENTS
-            collapsed = dict((i, new_args[i]) for i in range(len(new_args)) if i not in exclude_args)
-
-            for key in new_kwargs:
-                if key not in exclude_kwargs:
-                    collapsed[key] = new_kwargs[key]
+            # ONLY KEEP NON-EXCLUDED ARGUMENTS
+            collapsed = dict((i, new_args[i]) for i in range(len(new_args)) if i not in exclude)
+            collapsed.update(dict((key, value) for key, value in new_kwargs.items() if key not in exclude))
 
             points.append((collapsed, run.time))
 

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -478,9 +478,9 @@ class Timer(BaseTimer):
             for run in split.runs:
                 if transformers:
                     # if we have transformers for each split, go ahead and get this split
-                    if trans_op == 2 and i in transformers:
+                    if trans_op == 3 and i in transformers:
                         split_transformers = transformers[i]
-                    elif trans_op == 2 and split.label in transformers:
+                    elif trans_op == 3 and split.label in transformers:
                         split_transformers = transformers[split.label]
                     else:
                         split_transformers = transformers  # all transformers are for this split

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -478,23 +478,24 @@ class Timer(BaseTimer):
             for run in split.runs:
                 if transformers:
                     # if we have transformers for each split, go ahead and get this split
+                    split_transformers = None
                     if trans_op == 3 and i in transformers:
                         split_transformers = transformers[i]
                     elif trans_op == 3 and split.label in transformers:
                         split_transformers = transformers[split.label]
-                    else:
+                    elif trans_op == 2:
                         split_transformers = transformers  # all transformers are for this split
 
-                    args, kwargs = run.args[:], dict(run.kwargs)
+                    args, kwargs = list(run.args), dict(run.kwargs)
 
                     for j in range(len(args)):
-                        if trans_op == 1:  # we only have one function, so we transform everything with it
+                        if trans_op == 1:  # we only have one function, so transform everything with it
                             args[j] = transformers(args[j])
                         elif j in split_transformers:
                             args[j] = split_transformers[j](args[j])
 
                     for key in kwargs:
-                        if trans_op == 1:  # we only have one function, so we transform everything with it
+                        if trans_op == 1:  # we only have one function, so transform everything with it
                             kwargs[key] = transformers(kwargs[key])
                         elif key in split_transformers:
                             kwargs[key] = split_transformers[key](kwargs[key])

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -493,16 +493,15 @@ class Timer(BaseTimer):
 
         return "".join(string)
 
-    def best_fit_curve(self, curve_type: str=any, exclude_args: Set[int]=(), exclude_kwargs: set=(),
-                       split_index: Union[int, str]=-1, transformers: Dict[Union[str, int], callable]=()
-                       ) -> Union[None, Tuple[str, dict]]:
+    def best_fit_curve(self, curve_type: str=any, exclude: Set[Union[str, int]]=(), split_index: Union[int, str]=-1,
+                       transformers: Dict[Union[str, int], callable]=()) -> Union[None, Tuple[str, dict]]:
         """
         Determine the best fit curve for a split using logged arguments as the independent variable and the measured
         time as the dependent variable. By default, the most recent split is used. All non-excluded arguments must have
         integer values to allow curve calculation. If the values are not integers, then they must be transformed.
         :param curve_type: specify a specific curve type to determine the parameters for
-        :param exclude_args: the indices of the positional arguments to exclude when performing curve calculation
-        :param exclude_kwargs: the keys of the keyword arguments to exclude when performing curve calculation
+        :param exclude: the indices of the positional arguments or keys of keyword arguments to exclude when performing
+                    curve calculation
         :param split_index: The index or name of the split to determine the best fit curve for
         :param transformers: functions that take an argument and return an integer, as integers are needed for
                 determining the best fit curve. Positional arguments are denoted with integer keys denoting the position
@@ -512,8 +511,7 @@ class Timer(BaseTimer):
         """
         adjusted_index = -1 if split_index == -1 else self._adjust_split_index(split_index)
         if adjusted_index is not None:
-            return self.splits[adjusted_index].determine_best_fit(curve_type=curve_type, exclude_args=exclude_args,
-                                                                  exclude_kwargs=exclude_kwargs,
+            return self.splits[adjusted_index].determine_best_fit(curve_type=curve_type, exclude=exclude,
                                                                   transformers=transformers)
         else:
             raise RuntimeWarning("The split index/label {} is out of bounds/could not be found".format(adjusted_index))

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ with open("README.md", "r") as file:
 
 setuptools.setup(
     name="exectiming",
-    version="2.0.0rc3",
+    version="2.0.0rc4",
     author="Jacob Morris",
     author_email="blendingjake@gmail.com",
-    description="A Python package for measuring the execution time of code",
+    description="A Python module for measuring the execution time of code",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/blendingjake/exectiming",
@@ -41,5 +41,5 @@ setuptools.setup(
         "numpy",
         "matplotlib"
     ],
-    python_requires=">=3"
+    python_requires=">=3.3"
 )

--- a/tests/tests_basic.py
+++ b/tests/tests_basic.py
@@ -211,11 +211,6 @@ class TestTimerBasic(unittest.TestCase):
         self.assertRaisesRegex(RuntimeWarning, "The split index 'test' is not a valid index or label",
                                timer.output, "test")
 
-    def test_output_simple_transformers_with_all_splits(self):
-        timer = Timer()
-        self.assertRaisesRegex(RuntimeWarning, "'split_index' must be specified when 'transformers' is",
-                               timer.output, transformers={"test": len})
-
     def test_output_basic(self):
         out = StringIO()
 

--- a/tests/tests_basic.py
+++ b/tests/tests_basic.py
@@ -7,6 +7,24 @@ from time import sleep
 
 
 class TestStaticBasic(unittest.TestCase):
+    def test_context(self):
+        out = StringIO()
+
+        with StaticTimer.context(output_stream=out):
+            sleep(0.01)
+
+        self.assertEqual(out.getvalue().rstrip()[11:],
+                         "ms - Context                                    [runs=  1, iterations=  1]")
+
+    def test_context_with_args(self):
+        out = StringIO()
+
+        with StaticTimer.context(7, 10, test="test_value", label="Sleep", output_stream=out):
+            sleep(0.01)
+
+        self.assertEqual(out.getvalue().rstrip()[11:],
+                         "ms - Sleep(7, 10, test=test_value)              [runs=  1, iterations=  1]")
+
     def test_decorate(self):
         out = StringIO()
 
@@ -126,6 +144,24 @@ class TestStaticBasic(unittest.TestCase):
 
 
 class TestTimerBasic(unittest.TestCase):
+    def test_context(self):
+        timer = Timer(split=True)
+
+        with timer.context():
+            sleep(0.01)
+
+        self.assertEqual(timer.splits[-1].runs[-1].label, "Context")
+
+    def test_context_with_args(self):
+        timer = Timer(split=True)
+
+        with timer.context(7, 10, test="test_value", label="Sleep"):
+            sleep(0.01)
+
+        self.assertEqual(timer.splits[-1].runs[-1].label, "Sleep")
+        self.assertEqual(timer.splits[-1].runs[-1].args, (7, 10))
+        self.assertEqual(timer.splits[-1].runs[-1].kwargs, {"test": "test_value"})
+
     def test_decorate_basic(self):
         timer = Timer()
 

--- a/tests/tests_basic.py
+++ b/tests/tests_basic.py
@@ -240,6 +240,21 @@ class TestTimerBasic(unittest.TestCase):
         self.assertEqual(lines[0], "Split:")
         self.assertEqual(lines[1][17:], " - {:42} [runs=  1, iterations=  1] {:<20}".format("Test(5, 6, array=10)", ""))
 
+    def test_predict_invalid(self):
+        timer = Timer()
+        self.assertRaisesRegex(RuntimeWarning, "test is not a valid curve type", timer.predict, ("test", {}))
+
+    def test_predict_linear(self):
+        timer = Timer()
+        result = timer.predict(
+            ("Linear", {"b": 4, "x_0": 2, "x_test": 4}),
+            2,
+            test=3,
+            time_unit=timer.S
+        )
+
+        self.assertEqual(result, 2*2 + 4*3 + 4)
+
     def test_sort_basic(self):
         timer = Timer(split=True)
 

--- a/tests/tests_best_fit_curves.py
+++ b/tests/tests_best_fit_curves.py
@@ -69,7 +69,7 @@ class TestLinear(unittest.TestCase):
         result = timer.best_fit_curve()
         self.assertEqual(result[0], "Linear")
         self.assertEqual(result[1]["b"], 4)
-        self.assertEqual(result[1][0], 0)
+        self.assertEqual(result[1]["x_0"], 0)
 
     def test_sloped(self):
         timer = Timer(split=True)
@@ -80,7 +80,22 @@ class TestLinear(unittest.TestCase):
         result = timer.best_fit_curve()
         self.assertEqual(result[0], "Linear")
         self.assertEqual(result[1]["b"], 0)
-        self.assertEqual(result[1][0], 1)
+        self.assertEqual(result[1]["x_0"], 1)
+
+    def test_multi_variable(self):
+        timer = Timer(split=True)
+
+        for y, args, kwargs in ((1, (7, 12), {"a": 54}), (10, (43, 25), {"a": 65}), (35, (65, 43), {"a": 76})):
+            timer.splits[-1].add_run(Run(time=y, runs=1, iterations_per_run=1, label=str(y), args=args, kwargs=kwargs))
+
+        result = timer.best_fit_curve()
+        self.assertEqual(result[0], "Linear")
+
+        # don't care about the values, just want to make sure all the keys are there
+        self.assertIn("b", result[1])
+        self.assertIn("x_0", result[1])
+        self.assertIn("x_1", result[1])
+        self.assertIn("x_a", result[1])
 
 
 class TestLogarithmic(unittest.TestCase):

--- a/tests/tests_best_fit_curves.py
+++ b/tests/tests_best_fit_curves.py
@@ -19,13 +19,22 @@ class TestConsistentFeatures(unittest.TestCase):
                                curve_type="Test")
 
     def test_specific(self):
-        timer = Timer(split=True, start=True)
+        timer = Timer(split=True)
         timer.splits[-1].add_run(Run(time=e ** 2, runs=1, iterations_per_run=1, label=str(2), args=(2,)))
         timer.splits[-1].add_run(Run(time=e ** 5, runs=1, iterations_per_run=1, label=str(5), args=(5,)))
         timer.splits[-1].add_run(Run(time=e ** 8, runs=1, iterations_per_run=1, label=str(8), args=(8,)))
 
         # would normally return Exponential, make sure it doesn't
         self.assertEqual(timer.best_fit_curve(curve_type="Linear")[0], "Linear")
+
+    def test_exclude(self):
+        timer = Timer(split=True, start=True)
+
+        timer.log(5, {"age": 5}, name="Arthur")
+        timer.log(23, {"age": 34}, name="Roger")
+        timer.log(543, {"age": 43}, name="Sara")
+
+        self.assertNotEqual(timer.best_fit_curve(exclude={1, "name"}), None)  # make sure we actually found a curve
 
 
 class TestExponential(unittest.TestCase):
@@ -79,8 +88,8 @@ class TestLinear(unittest.TestCase):
 
         result = timer.best_fit_curve()
         self.assertEqual(result[0], "Linear")
-        self.assertEqual(result[1]["b"], 0)
-        self.assertEqual(result[1]["x_0"], 1)
+        self.assertEqual(round(result[1]["b"], 5), 0)
+        self.assertEqual(round(result[1]["x_0"], 5), 1)
 
     def test_multi_variable(self):
         timer = Timer(split=True)


### PR DESCRIPTION
* change `iterations` -> `iterations_per_run` and `unit` -> `time_unit` in `_format_output` to be consistent
* add `Timer.context()` and `StaticTimer.context()` which are context managers
* chance to require python 3.3 or greater as `perf_counter` isn't available earlier than that
* change linear best-fit-curve coefficents to be `x_index/name`, e.g. `x_0` or `x_array`
* merge `exclude_args` and `exclude_kwargs` into `exclude` in `Timer.best_fit_curve` and `Split.determine_best_fit`
* `unit` -> `time_unit` and add `rounding` to `_convert_time`
* add `Timer.predict()` that takes arguments and a best-fit-curve and predicts that execution time
* change `Timer.output()` and `Timer._str()` so that `transformers` can be just a callable, or a map of argument keys to callables or a map of split keys to a map of arguments keys to callables
* add tests
* correct some small bugs that were found



