### PR TITLE
Prep for 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude={1}, transformers
  two arguments, so `key=0` says to use the first as the independent variable and
  `transformer=len` will transform the list into an integer
  * Additionally, the title and x-axis labels are specified and rounding set lower
+ * The equation displayed on the plot uses the timescale specified by `time_unit`
 
 ### Plotting multiple splits
 ```python

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ timer.plot("sorted", plot_curve=True, curve=sorted_curve, title="Sorting Algorit
  * `title`, `x_label`, and `y_label` of the last call will be used
 
 ## TODO
+ - [x] Add parameter checking to `.plot()` and `.best_fit_curve()` to make sure 
+ arguments are integers to avoid difficult to decipher errors
  - [x] Change `.best_fit_curve()` to allow `transformers` to be a callable
  - [x] Change `.output()` to not require `split_index` if `transformers={0:len}`. 
  Allow `transformers` to be just a function, if there is only one argument, or a map 

--- a/README.md
+++ b/README.md
@@ -79,16 +79,21 @@ factorial(lambda: randint(3, 40))
 ```python
 from exectiming.exectiming import StaticTimer
 
-StaticTimer.time_it("pow(2, 64)", runs=5, iterations_per_run=10000)
-# 102.40978 ms - pow(2, 64) ... [runs=  5, iterations=10000]
+StaticTimer.time_it("pow(2, 64)", runs=10, iterations_per_run=10000)
+#  107.10668 ms - pow(2, 64) ... [runs= 10, iterations=10000]  
 
-StaticTimer.time_it("2**64", runs=5, iterations_per_run=10000)
-#  77.39217 ms - 2**64    ...   [runs=  5, iterations=10000]
+StaticTimer.time_it("2**64", runs=10, iterations_per_run=10000)
+#   68.75266 ms - 2**64 ... [runs= 10, iterations=10000] 
+
+StaticTimer.time_it("1<<64", runs=10, iterations_per_run=10000)
+#   65.53690 ms - 1<<64 ... [runs= 10, iterations=10000] 
 ```
 
  * Strings can be timed
  * Multiple runs can be measured then averaged together to get a more accurate result
- * Any needed `globals` or `locals` can be specified by passing `globals=` and `locals=`
+ * Anything needed names can be passed in by setting `globals=`, `locals=`, or `setup=`. 
+ The first two must be maps of names to objects. The second is a string that is 
+ executed once because the string `block` is timed.
 
 `time_it` can be used to re-write the decorator above example like so:
 ```python
@@ -122,38 +127,37 @@ bubble_sort(lambda: [randint(0, 1000) for _ in range(randint(100, 5000))])
 
 timer.output(split_index="bubble_sort", transformers={0: len})
 # bubble_sort:
-#     1360.32880 ms - bubble_sort(3004) ... [runs=  1, iterations=  1]
-#      726.70468 ms - bubble_sort(2201) ... [runs=  1, iterations=  1]
-#     3313.44760 ms - bubble_sort(4692) ... [runs=  1, iterations=  1]
-#      562.01346 ms - bubble_sort(1947) ... [runs=  1, iterations=  1]
-#      200.57170 ms - bubble_sort(1169) ... [runs=  1, iterations=  1]
+#     1333.19493 ms - bubble_sort(2141) ... [runs=  1, iterations=  1]                     
+#     1413.75243 ms - bubble_sort(2546) ... [runs=  1, iterations=  1]                     
+#     4247.70385 ms - bubble_sort(4530) ... [runs=  1, iterations=  1]                     
+#       34.01533 ms - bubble_sort(421)  ... [runs=  1, iterations=  1]                     
+#      675.07202 ms - bubble_sort(1752) ... [runs=  1, iterations=  1]   
 
 timer.statistics()
-# bubble_sort:
-#     Runs                5
-#     Total Time          6163.06623 ms
-#     Average             1232.61325 ms
-#     Standard Deviation  1106.06873 ms
-#     Variance            1223.38803 ms
+# bubble_sort[runs=5, total=7703.73856 ms]:
+#      Min | Max | Average = 34.01533 | 4247.70385 | 1540.74771 ms
+#       Standard Deviation = 1442.66797 ms
+#                 Variance = 2081.29087 ms
 
-timer.best_fit_curve(transformers=len)
-# ('Polynomial', {'b': -0.013786, 'x^0': 0.0, 'x^1': 0.0000066066, 'x^2': 0.000000149})
+print(timer.best_fit_curve(transformers=len))
+# ('Polynomial', {'a': 2.8042911992314363e-07, 'b': -9.670141667209306e-05, 'c': 0.024305228337961525})
 ```
 
  * `Timer` stores the output until requested
  * Function parameters can be transformed in the output. In the above example,
  `transformers={0: len}` indicates that the positional argument at index `0` should have its
- value in the output replaced by the result of calling the function with that parameter.
+ value in the output replaced by the result of calling the function with that parameter. 
  The output otherwise would have been something like `bubble_sort([1, 2, 3, 4, 5, ...])`
+ * `transformers=len` is also valid as all of the arguments can be transformed with `len`, so 
+ there is no need to specify which index/key the function should be used for.
  * Basic statistics can be displayed
  * A best-fit-curve can be determined. To use this, all logged function parameters
  must be integers. In this case, one was an a list, so it was transformed so that the
  analysis was done on the length of the list, instead of the list itself.
- * The resulting best fit curve is, if `n=len(list)`, `y = b + x^0*n^0 + x^1*n^1 + x^2*n^2`, where
- `x^2*n^2` is the coefficient `x^2` multiplied by n-squared. We can extrapolate
- using this curve to determine what the execution time of a list of list of
- length `n=10000`, which would be `-0.013786 + 0.0000066066*10000 + 0.000000149*10000^2`.
- That is `15.028 s` or `15028 ms`
+ * The resulting best fit curve is, if `x=len(list)`, `y = ax^2 + bx + c`. 
+ We can extrapolate execution time using this curve to determine how long it would 
+ take to sort a list of length `x=10000`, which would be 
+ `0.0000002804*10000^2 - 0.0000967*10000 + 0.0243`. That is `27.10 s` or `27100 ms`
 
 ### <a name="plotting">Plotting factorial</a>
 ```python
@@ -167,7 +171,7 @@ def factorial(n):
 factorial(lambda: randint(1, 100))
 timer.plot(plot_curve=True, time_unit=timer.US, equation_rounding=5)
 ```
-![Imgur Image](https://i.imgur.com/c00v9OB.png)
+![Imgur Image](https://imgur.com/7G1mDnO.png)
 
  * `.plot()` provides a quick way to plot the measured times against an argument
  that is the independent variable
@@ -182,7 +186,7 @@ bubble_sort(lambda: [randint(0, 100) for _ in range(randint(100, 2500))])
 curve = timer.best_fit_curve(transformers=len)
 timer.plot(transformer=len, plot_curve=True, curve=curve, x_label="List Length")
 ```
-![Imgur Image](https://imgur.com/cJ62w1Z.png)
+![Imgur Image](https://imgur.com/t2eZ0aN.png)
 
  * The curve can be determined beforehand and then passed into `plot()`
  * `plot()` needs `transformer=len` because the independent and dependent variables
@@ -212,7 +216,7 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude={1}, transformers
            transformer=len, time_unit=timer.US, x_label="List Length", equation_rounding=4,
            title="Binary Search - Random Size, Random Element")
 ```
-![Imgur Image](https://imgur.com/a9kNtL9.png)
+![Imgur Image](https://imgur.com/SeFfZHS.png)
 
  * `binary_search()` takes two arguments, so `best_fit_curve` is set to ignore
  the second one, at index 1, and to transform the argument at index 0 using `len`
@@ -220,6 +224,67 @@ timer.plot(plot_curve=True, curve=timer.best_fit_curve(exclude={1}, transformers
  two arguments, so `key=0` says to use the first as the independent variable and
  `transformer=len` will transform the list into an integer
  * Additionally, the title and x-axis labels are specified and rounding set lower
+
+### Plotting multiple splits
+```python
+from exectiming.exectiming import Timer
+from random import randint
+
+
+timer = Timer()
+
+
+def bubble_sort(array):
+    while True:
+        switched = False
+        for i in range(0, len(array)-1):
+            if array[i] > array[i+1]:
+                array[i], array[i+1] = array[i+1], array[i]
+                switched = True
+
+        if not switched:
+            break
+
+    return array
+
+
+def selection_sort(array):
+    for i in range(len(array) - 1):
+        # find min
+        min_i = i
+        for j in range(i+1, len(array)):
+            if array[j] < array[min_i]:
+                min_i = j
+
+        # swap
+        array[i], array[min_i] = array[min_i], array[i]
+
+    return array
+
+
+timer.time_it(bubble_sort, lambda: [randint(0, 1000) for _ in range(randint(100, 3000))], call_callable_args=True,
+              log_arguments=True, runs=10)
+timer.time_it(selection_sort, lambda: [randint(0, 1000) for _ in range(randint(100, 3000))], call_callable_args=True,
+              log_arguments=True, runs=10)
+timer.time_it(sorted, lambda: [randint(0, 1000) for _ in range(randint(100, 3000))], call_callable_args=True,
+              log_arguments=True, runs=10)
+
+
+bubble_sort_curve = timer.best_fit_curve("bubble_sort", transformers=len)
+selection_sort_curve = timer.best_fit_curve("selection_sort", transformers=len)
+sorted_curve = timer.best_fit_curve("sorted", transformers=len)
+
+timer.plot("bubble_sort", plot_curve=True, curve=bubble_sort_curve, multiple=True, transformer=len)
+timer.plot("selection_sort", plot_curve=True, curve=selection_sort_curve, multiple=True, transformer=len)
+timer.plot("sorted", plot_curve=True, curve=sorted_curve, title="Sorting Algorithms", x_label="List Length",
+           transformer=len)
+
+```
+![Imgur Image](https://imgur.com/zm1p6jz.png)
+
+ * Multiple splits and curves can be plotted by setting `multiple=True` for 
+ all but the last call to `.plot()`.
+ * `title`, `x_label`, and `y_label` of the last call will be used
 
 ## TODO
  - [x] Change `.best_fit_curve()` to allow `transformers` to be a callable

--- a/exectiming/best_fit_curves.py
+++ b/exectiming/best_fit_curves.py
@@ -210,7 +210,7 @@ class BestFitPolynomial(BestFitBase):
         values = curve_fit(lambda x, a, b, c: a*np.power(x, 2) + b*x + c, [val[0] for val in flattened_args],
                            matching_points, p0=(0.000001, 0.000001, 0.000001))
 
-        return {"a": values[0][0], "b": values[0][1], 0: 0, "c": values[0][2]}
+        return {"a": values[0][0], "b": values[0][1], "c": values[0][2]}
 
     @staticmethod
     def calculate_point(arguments, parameters):

--- a/exectiming/data_structures.py
+++ b/exectiming/data_structures.py
@@ -136,20 +136,20 @@ class Split:
     def statistics(self) -> Dict[str, Union[float, int]]:
         """
         Calculate all statistics and return them as a map. The statistics that will be calculated are: `min`, `max`,
-        `average`, `total_time`, `count`, `standard_deviation`, and `variance`
+        `average`, `total`, `count`, `standard_deviation`, and `variance`
         `average`: sum(x) / n
         `standard_deviation`: sqrt(sum (x - average)**2 / n)
         :return: a map of the key names listed above to the associated values
         """
         stats = {
-            "total_time": sum(run.time for run in self.runs),
+            "total": sum(run.time for run in self.runs),
             "min": min(run.time for run in self.runs),  # there are faster ways to get max and min,
             "max": max(run.time for run in self.runs),  # but the savings will be very minimal since len(runs) is small
             "count": len(self.runs)
         }
 
         if self.runs:
-            stats["average"] = stats["total_time"] / len(self.runs)
+            stats["average"] = stats["total"] / len(self.runs)
             stats["standard_deviation"] = sqrt(
                 sum((run.time - stats["average"]) ** 2 for run in self.runs) /
                 len(self.runs)

--- a/exectiming/data_structures.py
+++ b/exectiming/data_structures.py
@@ -46,12 +46,6 @@ class Split:
     def add_run(self, run: Run):
         self.runs.append(run)
 
-    def average(self) -> float:
-        if self.runs:
-            return sum(i.time for i in self.runs) / len(self.runs)
-        else:
-            return 0
-
     def determine_best_fit(self, curve_type: str=any, exclude: Set[Union[str, int]]=(),
                            transformers: Union[callable, Dict[Union[str, int], callable]]=()
                            ) -> Union[None, Tuple[str, dict]]:
@@ -139,20 +133,31 @@ class Split:
                     curve_type, ", ".join(self.best_fit_curves.keys())
                 ))
 
-    def standard_deviation(self) -> float:
+    def statistics(self) -> Dict[str, Union[float, int]]:
         """
-        Calculate the standard deviation of the runs contained within this split where SD is:
-        sqrt(sum (x - x_bar)**2 / n)
-        :return: the standard deviation
+        Calculate all statistics and return them as a map. The statistics that will be calculated are: `min`, `max`,
+        `average`, `total_time`, `count`, `standard_deviation`, and `variance`
+        `average`: sum(x) / n
+        `standard_deviation`: sqrt(sum (x - average)**2 / n)
+        :return: a map of the key names listed above to the associated values
         """
-        if self.runs:
-            avg = self.average()
-            return sqrt(sum((run.time - avg) ** 2 for run in self.runs) / len(self.runs))
-        else:
-            return 0
+        stats = {
+            "total_time": sum(run.time for run in self.runs),
+            "min": min(run.time for run in self.runs),  # there are faster ways to get max and min,
+            "max": max(run.time for run in self.runs),  # but the savings will be very minimal since len(runs) is small
+            "count": len(self.runs)
+        }
 
-    def variance(self) -> float:
         if self.runs:
-            return self.standard_deviation() ** 2
+            stats["average"] = stats["total_time"] / len(self.runs)
+            stats["standard_deviation"] = sqrt(
+                sum((run.time - stats["average"]) ** 2 for run in self.runs) /
+                len(self.runs)
+            )
+            stats["variance"] = stats["standard_deviation"] ** 2
         else:
-            return 0
+            stats["average"] = 0
+            stats["standard_deviation"] = 0
+            stats["variance"] = 0
+
+        return stats

--- a/exectiming/data_structures.py
+++ b/exectiming/data_structures.py
@@ -97,11 +97,11 @@ class Split:
             collapsed = dict((i, new_args[i]) for i in range(len(new_args)) if i not in exclude)
             collapsed.update(dict((key, value) for key, value in new_kwargs.items() if key not in exclude))
 
-            # ENSURE INTEGERS
+            # ENSURE INTEGERS OR FLOATS
             for value in collapsed.values():
-                if not isinstance(value, int):
+                if not isinstance(value, (int, float)):
                     raise RuntimeWarning(
-                        "All transformed, non-excluded argument values must be integers to determine a best-fit-curve"
+                        "All transformed, non-excluded argument values must be numbers to determine a best-fit-curve"
                     )
 
             points.append((collapsed, run.time))

--- a/exectiming/data_structures.py
+++ b/exectiming/data_structures.py
@@ -97,6 +97,13 @@ class Split:
             collapsed = dict((i, new_args[i]) for i in range(len(new_args)) if i not in exclude)
             collapsed.update(dict((key, value) for key, value in new_kwargs.items() if key not in exclude))
 
+            # ENSURE INTEGERS
+            for value in collapsed.values():
+                if not isinstance(value, int):
+                    raise RuntimeWarning(
+                        "All transformed, non-excluded argument values must be integers to determine a best-fit-curve"
+                    )
+
             points.append((collapsed, run.time))
 
         if curve_type is any:

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -580,17 +580,17 @@ class Timer(BaseTimer):
 
         return "".join(string)
 
-    def best_fit_curve(self, curve_type: str=any, exclude: Set[Union[str, int]]=(), split_index: Union[int, str]=-1,
+    def best_fit_curve(self, split_index: Union[int, str]=-1, curve_type: str=any, exclude: Set[Union[str, int]]=(),
                        transformers: Union[callable, Dict[Union[str, int], callable]]=()
                        ) -> Union[None, Tuple[str, dict]]:
         """
         Determine the best fit curve for a split using logged arguments as the independent variable and the measured
         time as the dependent variable. By default, the most recent split is used. All non-excluded arguments must have
         integer values to allow curve calculation. If the values are not integers, then they must be transformed.
+        :param split_index: The index or name of the split to determine the best fit curve for
         :param curve_type: specify a specific curve type to determine the parameters for
         :param exclude: the indices of the positional arguments or keys of keyword arguments to exclude when performing
                     curve calculation
-        :param split_index: The index or name of the split to determine the best fit curve for
         :param transformers: function(s) that take an argument and return an integer, as integers are needed for
                 determining the best fit curve. `transformers` can be formatted in one of two ways:
                 1. A callable which will be used with every argument that is encountered, aka, `transformers=len`
@@ -753,7 +753,7 @@ class Timer(BaseTimer):
 
     def plot(self, split_index: Union[str, int]=-1, key: Union[str, int]=None, transformer: callable=None,
              time_unit=BaseTimer.MS, y_label: str="Time", x_label: str=None, title: str=None, plot_curve: bool=False,
-             curve: Tuple[str, dict]=None, curve_steps: int=100, equation_rounding: int=8, plot_multiple=False):
+             curve: Tuple[str, dict]=None, curve_steps: int=100, equation_rounding: int=8, multiple=False):
         """
         Plot the runs in the specified split or the most recent split if none is specified. If there is more than one
         argument logged for the runs, then a key needs to be provided to use as the independent variable. The argument's
@@ -772,7 +772,7 @@ class Timer(BaseTimer):
                     returns it
         :param curve_steps: the number of points used when drawing the best fit curve, if `plot_curve`
         :param equation_rounding: the number of decimal places to round the equation to if `plot_curve`
-        :param plot_multiple: if `plot_multiple`, then this `.plot()` call will not cause the plot to be displayed,
+        :param multiple: if `plot_multiple`, then this `.plot()` call will not cause the plot to be displayed,
                     allowing subsequent calls to add more layers to the plot
         """
         if MISSING_MAT_PLOT:
@@ -859,7 +859,7 @@ class Timer(BaseTimer):
         if x_label is not None:
             plt.xlabel(x_label)
 
-        if not plot_multiple:
+        if not multiple:
             plt.show()
 
     def predict(self, parameters: Tuple[str, dict], *args, time_unit=BaseTimer.MS, rounding=8, **kwargs) -> float:

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -865,41 +865,29 @@ class Timer(BaseTimer):
                 continue
 
             stats = split.statistics()
-            self.output_stream.write("{}:\n".format(split.label))
+            self.output_stream.write("{}[runs={}, total={} {}]:\n".format(
+                split.label,
+                stats["count"],
+                self._convert_time(stats["total"], time_unit),
+                time_unit
+            ))
 
             # STATISTICS
-            self.output_stream.write("{}{:>20} {}\n".format(self.indent, "Runs", stats["count"]))
-            self.output_stream.write("{}{:>20} {} {}\n".format(
+            self.output_stream.write("{}{:>20} = {} | {} | {} {}\n".format(
                 self.indent,
-                "Total Time",
-                self._convert_time(stats["total_time"], time_unit),
-                time_unit
-            ))
-            self.output_stream.write("{}{:>20} {} {}\n".format(
-                self.indent,
-                "Min",
+                "Min | Max | Average",
                 self._convert_time(stats["min"], time_unit),
-                time_unit
-            ))
-            self.output_stream.write("{}{:>20} {} {}\n".format(
-                self.indent,
-                "Max",
                 self._convert_time(stats["max"], time_unit),
-                time_unit
-            ))
-            self.output_stream.write("{}{:>20} {} {}\n".format(
-                self.indent,
-                "Average",
                 self._convert_time(stats["average"], time_unit),
                 time_unit
             ))
-            self.output_stream.write("{}{:>20} {} {}\n".format(
+            self.output_stream.write("{}{:>20} = {} {}\n".format(
                 self.indent,
                 "Standard Deviation",
                 self._convert_time(stats["standard_deviation"], time_unit),
                 time_unit
             ))
-            self.output_stream.write("{}{:>20} {} {}\n".format(
+            self.output_stream.write("{}{:>20} = {} {}\n".format(
                 self.indent,
                 "Variance",
                 self._convert_time(stats["variance"], time_unit),

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -864,32 +864,45 @@ class Timer(BaseTimer):
             if not split.runs:  # skip splits with no logged times
                 continue
 
+            stats = split.statistics()
             self.output_stream.write("{}:\n".format(split.label))
 
             # STATISTICS
-            self.output_stream.write("{}{:<20}{}\n".format(self.indent, "Runs", len(split.runs)))
-            self.output_stream.write("{}{:<20}{} {}\n".format(
+            self.output_stream.write("{}{:>20} {}\n".format(self.indent, "Runs", stats["count"]))
+            self.output_stream.write("{}{:>20} {} {}\n".format(
                 self.indent,
                 "Total Time",
-                self._convert_time(sum(run.time for run in split.runs), time_unit),
+                self._convert_time(stats["total_time"], time_unit),
                 time_unit
             ))
-            self.output_stream.write("{}{:<20}{} {}\n".format(
+            self.output_stream.write("{}{:>20} {} {}\n".format(
+                self.indent,
+                "Min",
+                self._convert_time(stats["min"], time_unit),
+                time_unit
+            ))
+            self.output_stream.write("{}{:>20} {} {}\n".format(
+                self.indent,
+                "Max",
+                self._convert_time(stats["max"], time_unit),
+                time_unit
+            ))
+            self.output_stream.write("{}{:>20} {} {}\n".format(
                 self.indent,
                 "Average",
-                self._convert_time(split.average(), time_unit),
+                self._convert_time(stats["average"], time_unit),
                 time_unit
             ))
-            self.output_stream.write("{}{:<20}{} {}\n".format(
+            self.output_stream.write("{}{:>20} {} {}\n".format(
                 self.indent,
                 "Standard Deviation",
-                self._convert_time(split.standard_deviation(), time_unit),
+                self._convert_time(stats["standard_deviation"], time_unit),
                 time_unit
             ))
-            self.output_stream.write("{}{:<20}{} {}\n".format(
+            self.output_stream.write("{}{:>20} {} {}\n".format(
                 self.indent,
                 "Variance",
-                self._convert_time(split.variance(), time_unit),
+                self._convert_time(stats["variance"], time_unit),
                 time_unit
             ))
 

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -806,9 +806,9 @@ class Timer(BaseTimer):
             if transformer is not None:
                 value = transformer(value)
 
-            # ENSURE INTEGER
-            if not isinstance(value, int):
-                raise RuntimeWarning("All transformed, key values must be integers to plot")
+            # ENSURE INTEGER OR FLOATS
+            if not isinstance(value, (int, float)):
+                raise RuntimeWarning("All transformed, key values must be numbers to plot")
 
             x_values.append(value)
             y_values.append(self._convert_time(run.time, time_unit))

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -853,9 +853,7 @@ class Timer(BaseTimer):
         if x_label is not None:
             plt.xlabel(x_label)
 
-        if plot_multiple:
-            return None
-        else:
+        if not plot_multiple:
             plt.show()
 
     def predict(self, parameters: Tuple[str, dict], *args, time_unit=BaseTimer.MS, rounding=8, **kwargs) -> float:

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -210,7 +210,7 @@ class StaticTimer(BaseTimer):
         Otherwise, the measured time(s) will be returned along with the return value of the wrapped function
         :param runs: how many times the execution time of the wrapped function will be measured
         :param iterations_per_run: how many times the wrapped function will be called for each run. The time for the
-                    run will the sum of the times of iterations
+                    run will be the sum of the times of iterations
         :param average_runs: whether to average the measured times from all the runs together or not
         :param display: whether to display the measured time or to return it as
                     `Tuple[function return value: any, times: Union[float, List[float]]]`
@@ -354,7 +354,8 @@ class StaticTimer(BaseTimer):
         :param block: either a callable or a string
         :param args: any positional arguments to pass into `block` if it is callable
         :param runs: the number of times to measure the execution time
-        :param iterations_per_run: the number of times to execute the function for each run
+        :param iterations_per_run: the number of times to execute the function during each run. The time for the
+                    run will be the sum of the times of iterations
         :param average_runs: whether to average the runs together or not
         :param display: whether to display the measured time or to return it
         :param time_unit: the unit to display the measured time in if `display`
@@ -631,7 +632,8 @@ class Timer(BaseTimer):
         """
         A decorator that will time a function and store the measured time
         :param runs: the number times to measure the execution time
-        :param iterations_per_run: how many times to execute the function for each run
+        :param iterations_per_run: how many times to execute the function for each run. The time for the
+                    run will be the sum of the times of iterations
         :param call_callable_args: If True, then any `callable` arguments/parameters that are passed into the wrapped
                     function will be replaced with their return value. So `wrapped(callable)` will actually be
                     `wrapped(callable())`
@@ -1007,7 +1009,8 @@ class Timer(BaseTimer):
         :param block: either a callable or a string
         :param args: any positional arguments to pass into `block` if it is callable
         :param runs: the number of times to measure the execution time
-        :param iterations_per_run: the number of times to call/evaluate `block` for each run
+        :param iterations_per_run: the number of times to call/evaluate `block` for each run. The time for the
+                    run will be the sum of the times of iterations
         :param call_callable_args: If True, then any `callable` in `args` or `kwargs` will be replaced with their
                     return value. So `time_it(func, callable1, something=callable2)` will become
                     `func(callable1(), something=callable2())`. Only useful if `block` is callable

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -806,6 +806,10 @@ class Timer(BaseTimer):
             if transformer is not None:
                 value = transformer(value)
 
+            # ENSURE INTEGER
+            if not isinstance(value, int):
+                raise RuntimeWarning("All transformed, key values must be integers to plot")
+
             x_values.append(value)
             y_values.append(self._convert_time(run.time, time_unit))
 

--- a/exectiming/exectiming.py
+++ b/exectiming/exectiming.py
@@ -390,10 +390,11 @@ class StaticTimer(BaseTimer):
             if callable(block):
                 if call_callable_args:
                     run_args, run_kwargs = StaticTimer._call_callable_args(args, kwargs)
-                    if log_arguments:
-                        arguments.append((run_args, run_kwargs))
                 else:
                     run_args, run_kwargs = args, kwargs
+
+                if log_arguments:
+                    arguments.append((run_args, run_kwargs))
 
             st = StaticTimer._time()
             for _ in range(iterations_per_run):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r") as file:
 
 setuptools.setup(
     name="exectiming",
-    version="2.0.0",
+    version="2.0.1",
     author="Jacob Morris",
     author_email="blendingjake@gmail.com",
     description="A Python module for measuring the execution time of code",


### PR DESCRIPTION
Version 2.0.1
* change how `.statistics()` works behind the scenes and change how it formats the output
* add `copiers` to `.time_it()` and `.decorate()`, which are functions that will copy any arguments for each iteration in case the function has side-effects and modifies the parameter
* add `multiple` to `.plot()` to allow multiple splits to be graphed on the same plot
* add `setup` to `.time_it()` which is a string the will be executed once at the top if `block` is a string. Can be used to introduce needed names into the namespace
* add checks to ensure that only integer/float values are the independent variables for `.best_fit_curve()` and `.plot()`